### PR TITLE
发布 4.7.1

### DIFF
--- a/docs/self-hosted/deployment/docker/step-by-step.md
+++ b/docs/self-hosted/deployment/docker/step-by-step.md
@@ -8,7 +8,7 @@ This is a handy guide to deploying with Docker, as well as a breakdown of the [o
 
 ## Versions
 
-- Stable version - 4.7.0/latest - `ghcr.io/tryzealot/zealot:latest`
+- Stable version - 4.7.1/latest - `ghcr.io/tryzealot/zealot:latest`
 - Nightly version - develop - `ghcr.io/tryzealot/zealot:nightly` - Based on branch `develop` builds per commit.
 
 ## Registry

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/self-hosted/deployment/docker/step-by-step.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/self-hosted/deployment/docker/step-by-step.md
@@ -8,7 +8,7 @@ sidebar_label: "详细步骤"
 
 ## 版本列表
 
-- 稳定版本 - 4.7.0/latest - `ghcr.io/tryzealot/zealot:latest`
+- 稳定版本 - 4.7.1/latest - `ghcr.io/tryzealot/zealot:latest`
 - 测试版本 - develop - `ghcr.io/tryzealot/zealot:nightly` - 基于 develop 分支每次提交构建的版本
 
 ## 镜像仓库

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/changelog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/changelog.md
@@ -8,6 +8,20 @@
 
 :::
 
+## 4.7.1 (2023-03-10)
+
+支持最新 Android aapt2 构建工具生成的 aab 应用解析，详细[代码变更记录][4.7.1]
+
+#### 修复
+
+- `Web` 升级最新 appt2 模型避免 aab 解析异常
+- `Web` 解析异常的重复处理
+
+#### 新增
+
+- `Web` Android 应用解包详情页增加应用类型
+- `Web` 应用渠道编辑后调整原先的页面
+
 ## 4.7.0 (2023-03-03)
 
 #### 变更
@@ -468,7 +482,8 @@
 
 之前多年一直是公司内部开发和运营并没有开源，曾经承担过很多的功能到现在脱离出来专注提供应用托管和分发的服务。
 
-[未发布]: https://github.com/tryzealot/zealot/compare/4.7.0...HEAD
+[未发布]: https://github.com/tryzealot/zealot/compare/4.7.1...HEAD
+[4.7.1]: https://github.com/tryzealot/zealot/compare/4.7.0...4.7.1
 [4.7.0]: https://github.com/tryzealot/zealot/compare/4.6.0...4.7.0
 [4.6.0]: https://github.com/tryzealot/zealot/compare/4.5.3...4.6.0
 [4.5.3]: https://github.com/tryzealot/zealot/compare/4.5.2...4.5.3


### PR DESCRIPTION
支持最新 Android aapt2 构建工具生成的 aab 应用解析。

#### 修复

- `Web` 升级最新 appt2 模型避免 aab 解析异常
- `Web` 解析异常的重复处理

#### 新增

- `Web` Android 应用解包详情页增加应用类型
- `Web` 应用渠道编辑后调整原先的页面